### PR TITLE
Optional Markdown support 

### DIFF
--- a/src/qr-generator.coffee
+++ b/src/qr-generator.coffee
@@ -18,7 +18,7 @@
 # Nevertheless up to 900 characters should work in general.
 
 url = require 'url'
-
+mdOut = process.env.HUBOT_QR_MARKDOWN == 'true'
 baseUrl = 'https://api.qrserver.com/v1/create-qr-code'
 size = '128x128'
 
@@ -31,7 +31,11 @@ module.exports = (robot) ->
 
     urlObj = makeUrlObj data
     hackUrlObj = adapterHack urlObj, robot.adapterName
-    msg.send url.format hackUrlObj
+    mapUrl = url.format hackUrlObj
+    if mdOut
+      msg.send "![mapUrl](#{mapUrl})"
+    else
+      msg.send mapUrl
 
 makeUrlObj = (data) ->
   urlObj = url.parse baseUrl


### PR DESCRIPTION
This changeset add optional Markdown support which is useful with Mattermost servers for example.
Environment variable `HUBOT_QR_MARKDOWN` needed. 