### PR TITLE
Split tagpr and npm publish into separate workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish to npm
+        run: |
+          npm install -g npm@latest
+          npm ci
+          npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ jobs:
   tagpr:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: read
     steps:
       - name: Create GitHub App token
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   tagpr:
@@ -13,26 +12,18 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
-      id-token: write
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: npm
-          registry-url: 'https://registry.npmjs.org'
+          token: ${{ steps.app-token.outputs.token }}
       - name: Run tagpr
-        id: tagpr
         uses: Songmu/tagpr@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to npm
-        if: steps.tagpr.outputs.tag != ''
-        run: |
-          npm install -g npm@latest
-          npm ci
-          npm publish
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,9 @@ name: Test
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   test:
@@ -18,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           cache: npm
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Summary

- Split the release workflow into two: tagpr (Release) and npm publish (Publish)
- Use GitHub App token for tagpr to allow triggering downstream workflows (previously blocked by `GITHUB_TOKEN` event limitation)
- Publish workflow triggers on `release: published` event with OIDC provenance

## Prerequisites

- GitHub App configured with Contents (read/write), Pull requests (read/write), and Issues (read) permissions
- Repository variables/secrets: `APP_ID` (variable), `PRIVATE_KEY` (secret)
- npm Trusted Publishing configured for `publish.yml`